### PR TITLE
update packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ before_script:
   - java -jar t.jar -u init
   - rm t.jar
   - "/home/travis/jpm/bin/jpm install com.codacy:codacy-coverage-reporter:assembly"
-script: gradle test jacocoTestReport --info
+script: gradle test jacocoTestReport
 after_script:
   - "/home/travis/jpm/bin/codacy-coverage-reporter -l Java -r build/reports/jacoco/test/jacocoTestReport.xml --projectToken $CODACY_API_KEY"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springBootVersion = '1.3.1.RELEASE'
+        springBootVersion = '1.5.1.RELEASE'
     }
     repositories {
         mavenCentral()
@@ -8,14 +8,14 @@ buildscript {
     }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}") 
-        classpath('io.spring.gradle:dependency-management-plugin:0.5.2.RELEASE')
+        classpath('io.spring.gradle:dependency-management-plugin:0.6.1.RELEASE')
     }
 }
 
 apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'idea'
-apply plugin: 'spring-boot' 
+apply plugin: 'org.springframework.boot'
 apply plugin: 'io.spring.dependency-management'
 apply plugin: 'jacoco'
 
@@ -34,22 +34,26 @@ repositories {
 
 ext {
 	version = '0.0.1'
-	springCloudServiceBrokerVersion = '1.0.0.BUILD-SNAPSHOT'
+	springCloudServiceBrokerVersion = '1.0.0.RELEASE'
 }
 
 dependencies {
-    compile(group: 'org.springframework.boot', name: 'spring-boot-starter-jersey')
-    compile(group: 'org.springframework.cloud', name: 'spring-cloud-cloudfoundry-service-broker',
-    	version: springCloudServiceBrokerVersion)
-	compile(group: 'org.springframework.boot', name: 'spring-boot-configuration-processor')
-    compile(group: 'com.emc.ecs', name: 'object-client', version: '2.0.5')
-    compile(group: 'org.springframework.cloud', name: 'spring-cloud-cloudfoundry-service-broker',
-    	classifier: 'tests', version: springCloudServiceBrokerVersion)
-    testCompile(group: 'org.springframework.boot', name: 'spring-boot-starter-test')
-    testCompile(group: 'com.nitorcreations', name: 'junit-runners', version: '1.3')
-    testCompile(group: 'com.github.tomakehurst', name: 'wiremock', version: '1.57')
-    testCompile(group: 'org.powermock', name: 'powermock-api-mockito', version: '1.6.2')
-    testCompile(group: 'org.powermock', name: 'powermock-module-junit4', version: '1.6.2')
+    compile(group: 'org.springframework.boot', name: 'spring-boot-starter-jersey', version: springBootVersion)
+    compile(group: 'org.springframework.boot', name: 'spring-boot-configuration-processor', version: springBootVersion)
+
+    compile(group: 'org.springframework.cloud', name: 'spring-cloud-cloudfoundry-service-broker', version: springCloudServiceBrokerVersion)
+    compile(group: 'org.springframework.cloud', name: 'spring-cloud-cloudfoundry-service-broker', classifier: 'tests', version: springCloudServiceBrokerVersion)
+	
+    compile(group: 'com.emc.ecs', name: 'object-client', version: '3.0.0'){
+    	exclude module: "slf4j-log4j12"
+    }
+
+    testCompile(group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: springBootVersion)
+    testCompile(group: 'com.github.tomakehurst', name: 'wiremock-standalone', version: '2.5.1')
+    testCompile(group: 'org.powermock', name: 'powermock-api-mockito', version: '1.6.6')
+    testCompile(group: 'org.powermock', name: 'powermock-module-junit4', version: '1.6.6')
+    
+    
 }
 
 eclipse {
@@ -69,7 +73,7 @@ task wrapper(type: Wrapper) {
 
 task simulate(type:JavaExec) {
 	classpath sourceSets.test.runtimeClasspath
-	main = "com.emc.ecs.apiSimulator.Server"
+	main = "com.emc.ecs.management.simulator.Server"
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -40,15 +40,16 @@ ext {
 dependencies {
     compile(group: 'org.springframework.boot', name: 'spring-boot-starter-jersey', version: springBootVersion)
     compile(group: 'org.springframework.boot', name: 'spring-boot-configuration-processor', version: springBootVersion)
+    compile(group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: springBootVersion)
 
     compile(group: 'org.springframework.cloud', name: 'spring-cloud-cloudfoundry-service-broker', version: springCloudServiceBrokerVersion)
-    compile(group: 'org.springframework.cloud', name: 'spring-cloud-cloudfoundry-service-broker', classifier: 'tests', version: springCloudServiceBrokerVersion)
 	
     compile(group: 'com.emc.ecs', name: 'object-client', version: '3.0.0'){
     	exclude module: "slf4j-log4j12"
     }
 
     testCompile(group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: springBootVersion)
+    testCompile(group: 'org.springframework.cloud', name: 'spring-cloud-cloudfoundry-service-broker', version: springCloudServiceBrokerVersion, classifier: "tests")
     testCompile(group: 'com.github.tomakehurst', name: 'wiremock-standalone', version: '2.5.1')
     testCompile(group: 'org.powermock', name: 'powermock-api-mockito', version: '1.6.6')
     testCompile(group: 'org.powermock', name: 'powermock-module-junit4', version: '1.6.6')

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-bin.zip

--- a/src/main/java/com/emc/ecs/cloudfoundry/broker/config/BrokerConfig.java
+++ b/src/main/java/com/emc/ecs/cloudfoundry/broker/config/BrokerConfig.java
@@ -20,7 +20,7 @@ public class BrokerConfig {
     private String password = "ChangeMe";
     private String repositoryBucket = "repository";
     private String prefix = "ecs-cf-broker-";
-    private String brokerApiVersion = "2.8";
+    private String brokerApiVersion = "2.10";
     private String certificate = "localhost.pem";
 
     public String getManagementEndpoint() {

--- a/src/main/java/com/emc/ecs/management/sdk/Connection.java
+++ b/src/main/java/com/emc/ecs/management/sdk/Connection.java
@@ -5,7 +5,7 @@ import com.emc.ecs.cloudfoundry.broker.EcsManagementResourceNotFoundException;
 import com.emc.ecs.management.sdk.model.EcsManagementClientError;
 import org.glassfish.jersey.client.JerseyClientBuilder;
 import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
-import org.glassfish.jersey.filter.LoggingFilter;
+import org.glassfish.jersey.logging.LoggingFeature;
 
 import javax.net.ssl.*;
 import javax.ws.rs.client.Client;
@@ -146,9 +146,8 @@ public class Connection {
         if (!isLoggedIn())
             login();
         Client jerseyClient = buildJerseyClient();
-        Logger logger = Logger.getLogger(LoggingFilter.class.getName());
         Builder request = jerseyClient.target(uri)
-                .register(new LoggingFilter(logger, true)).request()
+                .register(LoggingFeature.class).request()
                 .header("X-SDS-AUTH-TOKEN", authToken)
                 .header("Accept", "application/xml");
         Response response;

--- a/src/test/java/com/emc/ecs/cloudfoundry/broker/config/CatalogConfigTest.java
+++ b/src/test/java/com/emc/ecs/cloudfoundry/broker/config/CatalogConfigTest.java
@@ -3,7 +3,7 @@ package com.emc.ecs.cloudfoundry.broker.config;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.ConfigFileApplicationContextInitializer;
+import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
 import org.springframework.cloud.servicebroker.model.Catalog;
 import org.springframework.cloud.servicebroker.model.Plan;
 import org.springframework.cloud.servicebroker.model.ServiceDefinition;

--- a/src/test/java/com/emc/ecs/cloudfoundry/broker/model/ServiceDefinitionProxyTest.java
+++ b/src/test/java/com/emc/ecs/cloudfoundry/broker/model/ServiceDefinitionProxyTest.java
@@ -5,7 +5,7 @@ import com.emc.ecs.cloudfoundry.broker.config.CatalogConfig;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.ConfigFileApplicationContextInitializer;
+import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
 import org.springframework.cloud.servicebroker.model.Plan;
 import org.springframework.cloud.servicebroker.model.ServiceDefinition;
 import org.springframework.test.context.ActiveProfiles;

--- a/src/test/java/com/emc/ecs/cloudfoundry/broker/repository/ServiceInstanceBindingRepositoryTest.java
+++ b/src/test/java/com/emc/ecs/cloudfoundry/broker/repository/ServiceInstanceBindingRepositoryTest.java
@@ -6,7 +6,7 @@ import com.emc.ecs.cloudfoundry.broker.config.Application;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.ConfigFileApplicationContextInitializer;
+import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;

--- a/src/test/java/com/emc/ecs/cloudfoundry/broker/repository/ServiceInstanceRepositoryTest.java
+++ b/src/test/java/com/emc/ecs/cloudfoundry/broker/repository/ServiceInstanceRepositoryTest.java
@@ -6,7 +6,7 @@ import com.emc.ecs.cloudfoundry.broker.config.Application;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.ConfigFileApplicationContextInitializer;
+import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;

--- a/src/test/resources/mappings/bucket-quota-edit-testbucket3.json
+++ b/src/test/resources/mappings/bucket-quota-edit-testbucket3.json
@@ -15,7 +15,7 @@
         },
         "bodyPatterns": [
         	{
-        		"equalToXml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><bucket_quota_param><blockSize>10</blockSize><namespace>ns1</namespace><notificationSize>8</notificationSize></bucket_quota_param>"
+        		"equalToXml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><bucket_quota_param><blockSize>10</blockSize><notificationSize>8</notificationSize><namespace>ns1</namespace></bucket_quota_param>"
         	}
         ]
     },


### PR DESCRIPTION
- Gradle 3.3
- Spring Boot 1.5.1
- Spring Cloud Broker 1.0.0.RELEASE
- ECS object client 3.0.0
- wiremock 2.5.1
- switched to wiremock-standalone as recommendation [getting started](http://wiremock.org/docs/getting-started/)
- relocated `ConfigFileApplicationContextInitializer`
- fixed bucket quota endpoint mapping
- fixed deprecated `LoggingFilter`
- Default Broker Api Version `2.10`
- Spring Boot Starter Actuator for enhanced Cloud Foundry integration
- move spring cloud cloudfoundry service broker to testCompile