### PR TITLE
extended certificate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ bundled ECS simulator.  For more info, check the
 | password           | ChangeMe       | false    | Password to authenticate to ECS management API     |
 | repositoryBucket   | repository     | false    | Internal bucket for metadata storage               |
 | prefix             | ecs-cf-broker- | false    | Prefix to prepend to ECS buckets and users         |
-| brokerApiVersion   | 2.8            | false    | Version of the CF broker API to advertise          |
+| brokerApiVersion   | 2.10           | false    | Version of the CF broker API to advertise          |
 | certificate        | -              | false    | ECS SSL public key cert file                       |
 
 If running within Eclipse, you can also set the environment variables using "Run Configuration" and "Environment" tabs.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ bundled ECS simulator.  For more info, check the
 | repositoryBucket   | repository     | false    | Internal bucket for metadata storage               |
 | prefix             | ecs-cf-broker- | false    | Prefix to prepend to ECS buckets and users         |
 | brokerApiVersion   | 2.8            | false    | Version of the CF broker API to advertise          |
-| certificate        | localhost.pem  | false    | ECS SSL public key cert file                       |
+| certificate        | -              | false    | ECS SSL public key cert file                       |
 
 If running within Eclipse, you can also set the environment variables using "Run Configuration" and "Environment" tabs.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ECS Cloud Foundry Service Broker
-[![Build Status](https://travis-ci.org/emccode/ecs-cf-service-broker.svg?branch=master)](https://travis-ci.org/emccode/ecs-cf-service-broker) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/1a414678d5bd473685c29b217ae1c7e4)](https://www.codacy.com/app/spiegela/ecs-cf-service-broker?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=emccode/ecs-cf-service-broker&amp;utm_campaign=Badge_Grade)
+[![Build Status](https://travis-ci.org/codedellemc/ecs-cf-service-broker.svg?branch=master)](https://travis-ci.org/codedellemc/ecs-cf-service-broker) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/1a414678d5bd473685c29b217ae1c7e4)](https://www.codacy.com/app/spiegela/ecs-cf-service-broker?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=emccode/ecs-cf-service-broker&amp;utm_campaign=Badge_Grade)
 ## Description
 
 This service broker enables Cloud Foundry applications to create, delete and
@@ -40,7 +40,7 @@ To build, make sure that you have a Java 8 runtime environment, and use Gradle.
 The service broker supports a number of configuration parameters that are available as environment variables or through
 Spring configuration.  All parameters are prefixed with the `broker-config.` string.  Default parameters point to the
 bundled ECS simulator.  For more info, check the
-[default config](https://github.com/spiegela/ecs-cf-service-broker/blob/master/src/main/resources/application.yml).
+[default config](https://github.com/codedellemc/ecs-cf-service-broker/blob/master/src/main/resources/application.yml).
 
 | Parameter          | Default Value  | Required | Description                                        |
 | ------------------ |:--------------:| -------- | -------------------------------------------------- |

--- a/src/main/java/com/emc/ecs/cloudfoundry/broker/config/Application.java
+++ b/src/main/java/com/emc/ecs/cloudfoundry/broker/config/Application.java
@@ -31,15 +31,15 @@ public class Application {
 
     @Bean
     public Connection ecsConnection() {
-    	if (broker.getCertificate() != null) {
-	        URL certificate = Thread.currentThread().getContextClassLoader()
-	                .getResource(broker.getCertificate());
-	        return new Connection(broker.getManagementEndpoint(),
-	                broker.getUsername(), broker.getPassword(), certificate);
-    	} else {
-    		return new Connection(broker.getManagementEndpoint(),
-	                broker.getUsername(), broker.getPassword());
-    	}
+	if (broker.getCertificate() != null) {
+        URL certificate = Thread.currentThread().getContextClassLoader()
+                .getResource(broker.getCertificate());
+        return new Connection(broker.getManagementEndpoint(),
+                broker.getUsername(), broker.getPassword(), certificate);
+	} else {
+		return new Connection(broker.getManagementEndpoint(),
+                broker.getUsername(), broker.getPassword());
+	}
     }
 
     @Bean

--- a/src/main/java/com/emc/ecs/cloudfoundry/broker/config/Application.java
+++ b/src/main/java/com/emc/ecs/cloudfoundry/broker/config/Application.java
@@ -31,10 +31,15 @@ public class Application {
 
     @Bean
     public Connection ecsConnection() {
-        URL certificate = Thread.currentThread().getContextClassLoader()
-                .getResource(broker.getCertificate());
-        return new Connection(broker.getManagementEndpoint(),
-                broker.getUsername(), broker.getPassword(), certificate);
+    	if (broker.getCertificate() != null) {
+	        URL certificate = Thread.currentThread().getContextClassLoader()
+	                .getResource(broker.getCertificate());
+	        return new Connection(broker.getManagementEndpoint(),
+	                broker.getUsername(), broker.getPassword(), certificate);
+    	} else {
+    		return new Connection(broker.getManagementEndpoint(),
+	                broker.getUsername(), broker.getPassword());
+    	}
     }
 
     @Bean

--- a/src/main/java/com/emc/ecs/cloudfoundry/broker/config/BrokerConfig.java
+++ b/src/main/java/com/emc/ecs/cloudfoundry/broker/config/BrokerConfig.java
@@ -21,7 +21,7 @@ public class BrokerConfig {
     private String repositoryBucket = "repository";
     private String prefix = "ecs-cf-broker-";
     private String brokerApiVersion = "2.10";
-    private String certificate = "localhost.pem";
+    private String certificate;
 
     public String getManagementEndpoint() {
         return managementEndpoint;

--- a/src/main/java/com/emc/ecs/cloudfoundry/broker/repository/ServiceInstanceBindingRepository.java
+++ b/src/main/java/com/emc/ecs/cloudfoundry/broker/repository/ServiceInstanceBindingRepository.java
@@ -8,6 +8,7 @@ import com.emc.object.s3.bean.GetObjectResult;
 import com.emc.object.s3.jersey.S3JerseyClient;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import com.sun.jersey.client.urlconnection.URLConnectionClientHandler;
 
 import javax.annotation.PostConstruct;
 import javax.xml.bind.JAXBException;
@@ -37,7 +38,7 @@ public class ServiceInstanceBindingRepository {
                 new URI(broker.getRepositoryEndpoint()));
         s3Config.withIdentity(broker.getPrefixedUserName())
                 .withSecretKey(broker.getRepositorySecret());
-        this.s3 = new S3JerseyClient(s3Config);
+        this.s3 = new S3JerseyClient(s3Config, new URLConnectionClientHandler());
         this.bucket = broker.getPrefixedBucketName();
     }
 

--- a/src/main/java/com/emc/ecs/cloudfoundry/broker/repository/ServiceInstanceBindingRepository.java
+++ b/src/main/java/com/emc/ecs/cloudfoundry/broker/repository/ServiceInstanceBindingRepository.java
@@ -38,7 +38,8 @@ public class ServiceInstanceBindingRepository {
                 new URI(broker.getRepositoryEndpoint()));
         s3Config.withIdentity(broker.getPrefixedUserName())
                 .withSecretKey(broker.getRepositorySecret());
-        this.s3 = new S3JerseyClient(s3Config, new URLConnectionClientHandler());
+        this.s3 = new S3JerseyClient(s3Config,
+        		new URLConnectionClientHandler());
         this.bucket = broker.getPrefixedBucketName();
     }
 

--- a/src/main/java/com/emc/ecs/cloudfoundry/broker/repository/ServiceInstanceRepository.java
+++ b/src/main/java/com/emc/ecs/cloudfoundry/broker/repository/ServiceInstanceRepository.java
@@ -8,6 +8,7 @@ import com.emc.object.s3.bean.GetObjectResult;
 import com.emc.object.s3.jersey.S3JerseyClient;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import com.sun.jersey.client.urlconnection.URLConnectionClientHandler;
 
 import javax.annotation.PostConstruct;
 import javax.xml.bind.JAXBException;
@@ -37,7 +38,7 @@ public class ServiceInstanceRepository {
                 new URI(broker.getRepositoryEndpoint()));
         s3Config.withIdentity(broker.getPrefixedUserName())
                 .withSecretKey(broker.getRepositorySecret());
-        this.s3 = new S3JerseyClient(s3Config);
+        this.s3 = new S3JerseyClient(s3Config, new URLConnectionClientHandler());
         this.bucket = broker.getPrefixedBucketName();
     }
 

--- a/src/main/java/com/emc/ecs/cloudfoundry/broker/repository/ServiceInstanceRepository.java
+++ b/src/main/java/com/emc/ecs/cloudfoundry/broker/repository/ServiceInstanceRepository.java
@@ -38,7 +38,8 @@ public class ServiceInstanceRepository {
                 new URI(broker.getRepositoryEndpoint()));
         s3Config.withIdentity(broker.getPrefixedUserName())
                 .withSecretKey(broker.getRepositorySecret());
-        this.s3 = new S3JerseyClient(s3Config, new URLConnectionClientHandler());
+        this.s3 = new S3JerseyClient(s3Config,
+        		new URLConnectionClientHandler());
         this.bucket = broker.getPrefixedBucketName();
     }
 

--- a/src/main/java/com/emc/ecs/management/sdk/Connection.java
+++ b/src/main/java/com/emc/ecs/management/sdk/Connection.java
@@ -65,8 +65,8 @@ public class Connection {
         ClientBuilder builder;
         if (certificate != null) {
             /**
-            * Disable host name verification. Should be able to configure the ECS
-            * certificate with the correct host name to avoid this.
+            * Disable host name verification. Should be able to configure the
+            * ECS certificate with the correct host name to avoid this.
             **/
             HostnameVerifier hostnameVerifier = getHostnameVerifier();
             HttpsURLConnection.setDefaultHostnameVerifier(hostnameVerifier);

--- a/src/main/java/com/emc/ecs/management/sdk/Connection.java
+++ b/src/main/java/com/emc/ecs/management/sdk/Connection.java
@@ -62,21 +62,21 @@ public class Connection {
     }
 
     private Client buildJerseyClient() throws EcsManagementClientException {
-	    ClientBuilder builder;
-	    if (certificate != null) {
-		    /**
-			 * Disable host name verification. Should be able to configure the ECS
-			 * certificate with the correct host name to avoid this.
-			 **/
-			HostnameVerifier hostnameVerifier = getHostnameVerifier();
-			HttpsURLConnection.setDefaultHostnameVerifier(hostnameVerifier);
-			builder = ClientBuilder.newBuilder()
-				.register(hostnameVerifier);
-			builder.sslContext(getSSLContext());
-	    } else {
-	    	builder = ClientBuilder.newBuilder();
-	    }	
-		return builder.build();
+    ClientBuilder builder;
+    if (certificate != null) {
+	    /**
+		 * Disable host name verification. Should be able to configure the ECS
+		 * certificate with the correct host name to avoid this.
+		 **/
+		HostnameVerifier hostnameVerifier = getHostnameVerifier();
+		HttpsURLConnection.setDefaultHostnameVerifier(hostnameVerifier);
+		builder = ClientBuilder.newBuilder()
+			.register(hostnameVerifier);
+		builder.sslContext(getSSLContext());
+    } else {
+    	builder = ClientBuilder.newBuilder();
+    }	
+	return builder.build();
     }
 
     private SSLContext getSSLContext() throws EcsManagementClientException {

--- a/src/main/java/com/emc/ecs/management/sdk/Connection.java
+++ b/src/main/java/com/emc/ecs/management/sdk/Connection.java
@@ -3,7 +3,6 @@ package com.emc.ecs.management.sdk;
 import com.emc.ecs.cloudfoundry.broker.EcsManagementClientException;
 import com.emc.ecs.cloudfoundry.broker.EcsManagementResourceNotFoundException;
 import com.emc.ecs.management.sdk.model.EcsManagementClientError;
-import org.glassfish.jersey.client.JerseyClientBuilder;
 import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
 import org.glassfish.jersey.logging.LoggingFeature;
 
@@ -63,19 +62,21 @@ public class Connection {
     }
 
     private Client buildJerseyClient() throws EcsManagementClientException {
-        /**
-         * Disable host name verification. Should be able to configure the ECS
-         * certificate with the correct host name to avoid this.
-         **/
-        HostnameVerifier hostnameVerifier = getHostnameVerifier();
-        HttpsURLConnection.setDefaultHostnameVerifier(hostnameVerifier);
-        ClientBuilder builder = JerseyClientBuilder.newBuilder()
-                .register(hostnameVerifier);
-
-        if (certificate != null) {
-            builder.sslContext(getSSLContext());
-        }
-        return builder.build();
+	    ClientBuilder builder;
+	    if (certificate != null) {
+		    /**
+			 * Disable host name verification. Should be able to configure the ECS
+			 * certificate with the correct host name to avoid this.
+			 **/
+			HostnameVerifier hostnameVerifier = getHostnameVerifier();
+			HttpsURLConnection.setDefaultHostnameVerifier(hostnameVerifier);
+			builder = ClientBuilder.newBuilder()
+				.register(hostnameVerifier);
+			builder.sslContext(getSSLContext());
+	    } else {
+	    	builder = ClientBuilder.newBuilder();
+	    }	
+		return builder.build();
     }
 
     private SSLContext getSSLContext() throws EcsManagementClientException {

--- a/src/main/java/com/emc/ecs/management/sdk/Connection.java
+++ b/src/main/java/com/emc/ecs/management/sdk/Connection.java
@@ -62,21 +62,21 @@ public class Connection {
     }
 
     private Client buildJerseyClient() throws EcsManagementClientException {
-    ClientBuilder builder;
-    if (certificate != null) {
-	    /**
-		 * Disable host name verification. Should be able to configure the ECS
-		 * certificate with the correct host name to avoid this.
-		 **/
-		HostnameVerifier hostnameVerifier = getHostnameVerifier();
-		HttpsURLConnection.setDefaultHostnameVerifier(hostnameVerifier);
-		builder = ClientBuilder.newBuilder()
-			.register(hostnameVerifier);
-		builder.sslContext(getSSLContext());
-    } else {
-    	builder = ClientBuilder.newBuilder();
-    }	
-	return builder.build();
+        ClientBuilder builder;
+        if (certificate != null) {
+            /**
+            * Disable host name verification. Should be able to configure the ECS
+            * certificate with the correct host name to avoid this.
+            **/
+            HostnameVerifier hostnameVerifier = getHostnameVerifier();
+            HttpsURLConnection.setDefaultHostnameVerifier(hostnameVerifier);
+            builder = ClientBuilder.newBuilder()
+                    .register(hostnameVerifier);
+            builder.sslContext(getSSLContext());
+        } else {
+            builder = ClientBuilder.newBuilder();
+        }	
+        return builder.build();
     }
 
     private SSLContext getSSLContext() throws EcsManagementClientException {


### PR DESCRIPTION
- removed requirement to provide certificate
- Server Name Indication (SNI) support for object client
  - the http client version used in [smart-client-java](https://github.com/EMCECS/smart-client-java/blob/master/build.gradle#L42) is older than `4.3.2` required to support SNI
  - `HttpURLConnection` is used for constructing the `S3Client` instead, which supports SNI
- README updates