### PR TITLE
Improve bindings & fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ The following feature flags are supported by the bucket & namespace.  All parame
 | bucket binding    | base-url            | -       | String   | Base URL name for object URI                   |
 | bucket binding    | use-ssl             | false   | Boolean  | Use SSL for object endpoint                    |
 | bucket binding    | permissions         | -       | JSON List| List of permissions for user in bucket ACL     |
+| bucket binding    | path-style-access   | true    | Boolean  | Use path style access for S3 URL, the alternative is to use host style access |
 | namespace         | domain-group-admins | -       | JSON List| List of domain admins to be added to namespace |
 | namespace         | encrypted           | false   | Boolean  | Enable encryption of namespace                 |
 | namespace         | compliance-enabled  | false   | Boolean  | Enable compliance adhearance of retention      |
@@ -148,6 +149,7 @@ The following feature flags are supported by the bucket & namespace.  All parame
 | namespace         | default-retention   | -       | Int      | Number of seconds to prevent object deletion/modification |
 | namespace binding | base-url            | -       | String   | Base URL name for object URI                   |
 | namespace binding | use-ssl             | false   | Boolean  | Use SSL for object endpoint                    |
+| namespace binding | permissions         | -       | JSON List| List of permissions for user in bucket ACL     |
 
 \* Quotas are defined with the following format: `{quota: {limit: <int>, warn: <int>}}`
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,6 @@ The following feature flags are supported by the bucket & namespace.  All parame
 | namespace         | default-retention   | -       | Int      | Number of seconds to prevent object deletion/modification |
 | namespace binding | base-url            | -       | String   | Base URL name for object URI                   |
 | namespace binding | use-ssl             | false   | Boolean  | Use SSL for object endpoint                    |
-| namespace binding | permissions         | -       | JSON List| List of permissions for user in bucket ACL     |
 
 \* Quotas are defined with the following format: `{quota: {limit: <int>, warn: <int>}}`
 

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,8 @@ dependencies {
     testCompile(group: 'com.github.tomakehurst', name: 'wiremock-standalone', version: '2.5.1')
     testCompile(group: 'org.powermock', name: 'powermock-api-mockito', version: '1.7.1')
     testCompile(group: 'org.powermock', name: 'powermock-module-junit4', version: '1.7.1')
-    
+    testCompile(group: 'com.github.paulcwarren', name: 'ginkgo4j', version: '1.0.7')
+
     
 }
 

--- a/src/main/java/com/emc/ecs/cloudfoundry/broker/config/BrokerConfig.java
+++ b/src/main/java/com/emc/ecs/cloudfoundry/broker/config/BrokerConfig.java
@@ -162,6 +162,7 @@ public class BrokerConfig {
     public void setObjectEndpoint(String objectEndpoint) {
         this.objectEndpoint = objectEndpoint;
     }
+
     public String getNfsMountHost() {
         return nfsMountHost;
     }

--- a/src/main/java/com/emc/ecs/cloudfoundry/broker/service/BindingWorkflow.java
+++ b/src/main/java/com/emc/ecs/cloudfoundry/broker/service/BindingWorkflow.java
@@ -16,7 +16,8 @@ public interface BindingWorkflow {
     void checkIfUserExists() throws EcsManagementClientException, IOException;
     String createBindingUser() throws EcsManagementClientException, IOException, JAXBException;
     void removeBinding(ServiceInstanceBinding binding) throws EcsManagementClientException, IOException, JAXBException;
-    Map<String, Object> getCredentials(String secretKey) throws IOException, EcsManagementClientException;
+    Map<String, Object> getCredentials(String secretKey, Map<String, Object> parameters)
+            throws IOException, EcsManagementClientException;
     ServiceInstanceBinding getBinding(Map<String, Object> credentials);
     CreateServiceInstanceAppBindingResponse getResponse(Map<String, Object> credentials);
 }

--- a/src/main/java/com/emc/ecs/cloudfoundry/broker/service/BucketBindingWorkflow.java
+++ b/src/main/java/com/emc/ecs/cloudfoundry/broker/service/BucketBindingWorkflow.java
@@ -43,27 +43,24 @@ public class BucketBindingWorkflow extends BindingWorkflowImpl {
         ServiceInstance instance = instanceRepository.find(instanceId);
         if (instance == null)
             throw new ServiceInstanceDoesNotExistException(instanceId);
+
         String bucketName = instance.getName();
-
+        String export = "";
+        List<String> permissions = null;
         if (parameters != null) {
-
-            @SuppressWarnings(value = "unchecked")
-            List<String> permissions = (List<String>) parameters.get("permissions");
-            if (permissions == null) {
-                ecs.addUserToBucket(bucketName, bindingId);
-            } else {
-                ecs.addUserToBucket(bucketName, bindingId, permissions);
-            }
-
-            if (ecs.getBucketFileEnabled(bucketName)) {
-                String export = (String) parameters.get("export");
-                if (export == null)
-                    export = "";
-                volumeMounts = createVolumeExport(export, new URL(ecs.getObjectEndpoint()), parameters);
-            }
-
-        } else {
+            permissions = (List<String>) parameters.get("permissions");
+            export = (String) parameters.getOrDefault("export", "");
+        }
+        
+        if (permissions == null) {
             ecs.addUserToBucket(bucketName, bindingId);
+        } else {
+            ecs.addUserToBucket(bucketName, bindingId, permissions);
+        }
+
+        if (ecs.getBucketFileEnabled(bucketName)) {
+            volumeMounts = createVolumeExport(export,
+                    new URL(ecs.getObjectEndpoint()), parameters);
         }
 
         return userSecretKey.getSecretKey();

--- a/src/main/java/com/emc/ecs/cloudfoundry/broker/service/EcsServiceInstanceBindingService.java
+++ b/src/main/java/com/emc/ecs/cloudfoundry/broker/service/EcsServiceInstanceBindingService.java
@@ -61,7 +61,8 @@ public class EcsServiceInstanceBindingService
             String secretKey = workflow.createBindingUser();
 
             LOG.info("building binding response");
-            Map<String, Object> credentials = workflow.getCredentials(secretKey);
+            Map<String, Object> credentials = workflow.getCredentials(secretKey,
+                    request.getParameters());
             ServiceInstanceBinding binding = workflow.getBinding(credentials);
 
             LOG.info("saving binding...");

--- a/src/main/java/com/emc/ecs/cloudfoundry/broker/service/NamespaceBindingWorkflow.java
+++ b/src/main/java/com/emc/ecs/cloudfoundry/broker/service/NamespaceBindingWorkflow.java
@@ -40,7 +40,7 @@ public class NamespaceBindingWorkflow extends BindingWorkflowImpl {
     }
 
     @Override
-    public Map<String, Object> getCredentials(String secretKey)
+    public Map<String, Object> getCredentials(String secretKey, Map<String, Object> parameters)
             throws IOException, EcsManagementClientException {
         ServiceInstance instance = instanceRepository.find(instanceId);
         if (instance == null)

--- a/src/main/java/com/emc/ecs/cloudfoundry/broker/service/RemoteConnectBindingWorkflow.java
+++ b/src/main/java/com/emc/ecs/cloudfoundry/broker/service/RemoteConnectBindingWorkflow.java
@@ -39,7 +39,8 @@ public class RemoteConnectBindingWorkflow extends BindingWorkflowImpl {
     }
 
     @Override
-    public Map<String, Object> getCredentials(String secretKey) throws IOException, EcsManagementClientException {
+    public Map<String, Object> getCredentials(String secretKey, Map<String, Object> parameters)
+            throws IOException, EcsManagementClientException {
         Map<String, Object> credentials = new HashMap<>();
         credentials.put("accessKey", bindingId);
         credentials.put("secretKey", secretKey);

--- a/src/test/java/com/emc/ecs/TestSuite.java
+++ b/src/test/java/com/emc/ecs/TestSuite.java
@@ -4,6 +4,7 @@ import com.emc.ecs.cloudfoundry.broker.config.CatalogConfigTest;
 import com.emc.ecs.cloudfoundry.broker.model.ServiceDefinitionProxyTest;
 import com.emc.ecs.cloudfoundry.broker.repository.ServiceInstanceBindingRepositoryTest;
 import com.emc.ecs.cloudfoundry.broker.repository.ServiceInstanceRepositoryTest;
+import com.emc.ecs.cloudfoundry.broker.service.BucketBindingWorkflowTest;
 import com.emc.ecs.cloudfoundry.broker.service.EcsServiceInstanceBindingServiceTest;
 import com.emc.ecs.cloudfoundry.broker.service.EcsServiceInstanceServiceTest;
 import com.emc.ecs.cloudfoundry.broker.service.EcsServiceTest;
@@ -38,7 +39,8 @@ import org.junit.runners.Suite.SuiteClasses;
         ServiceInstanceBindingRepositoryTest.class,
         ServiceInstanceRepositoryTest.class,
         EcsServiceInstanceBindingServiceTest.class,
-        EcsServiceInstanceServiceTest.class
+        EcsServiceInstanceServiceTest.class,
+        BucketBindingWorkflowTest.class
     })
 public class TestSuite {
 

--- a/src/test/java/com/emc/ecs/cloudfoundry/broker/service/BucketBindingWorkflowTest.java
+++ b/src/test/java/com/emc/ecs/cloudfoundry/broker/service/BucketBindingWorkflowTest.java
@@ -1,0 +1,337 @@
+package com.emc.ecs.cloudfoundry.broker.service;
+
+import com.emc.ecs.cloudfoundry.broker.repository.ServiceInstanceBinding;
+import com.emc.ecs.cloudfoundry.broker.repository.ServiceInstanceRepository;
+import com.emc.ecs.management.sdk.model.UserSecretKey;
+import com.github.paulcwarren.ginkgo4j.Ginkgo4jRunner;
+import org.assertj.core.util.Lists;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.stubbing.Answer;
+import org.springframework.cloud.servicebroker.exception.ServiceInstanceBindingExistsException;
+import org.springframework.cloud.servicebroker.exception.ServiceInstanceDoesNotExistException;
+import org.springframework.cloud.servicebroker.model.CreateServiceInstanceAppBindingResponse;
+import org.springframework.cloud.servicebroker.model.CreateServiceInstanceBindingRequest;
+import org.springframework.cloud.servicebroker.model.VolumeMount;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.emc.ecs.common.Fixtures.*;
+import static com.github.paulcwarren.ginkgo4j.Ginkgo4jDSL.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+
+@RunWith(Ginkgo4jRunner.class)
+public class BucketBindingWorkflowTest {
+
+    private EcsService ecs;
+    private ServiceInstanceRepository instanceRepo;
+    private Map<String, Object> parameters = new HashMap<>();
+    private Map<String, Object> credentials = new HashMap<>();
+    @SuppressWarnings("unchecked")
+    private Class<List<String>> listClass = (Class<List<String>>) (Class) ArrayList.class;
+    private ArgumentCaptor<List<String>> permsCaptor = ArgumentCaptor.forClass(listClass);
+    private ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
+    private BindingWorkflow workflow;
+
+    {
+        Describe("BucketBindingWorkflow", () -> {
+            BeforeEach(() -> {
+                ecs = mock(EcsService.class);
+                instanceRepo = mock(ServiceInstanceRepository.class);
+                workflow = new BucketBindingWorkflow(instanceRepo, ecs);
+            });
+
+            Context("with binding ID conflict", () -> {
+                BeforeEach(() ->
+                        when(ecs.userExists(eq(BINDING_ID))).thenReturn(true));
+
+                It("should throw an binding-exists exception", () -> {
+                    try {
+                        workflow.checkIfUserExists();
+                    } catch (ServiceInstanceBindingExistsException e) {
+                        assert e.getClass().equals(ServiceInstanceBindingExistsException.class);
+                    }
+                });
+            });
+
+            Context("without binding ID conflict", () -> {
+                BeforeEach(() -> {
+                    CreateServiceInstanceBindingRequest req = bucketBindingRequestFixture();
+                    workflow = workflow.withCreateRequest(req);
+                    when(ecs.userExists(eq(BINDING_ID))).thenReturn(false);
+                });
+
+                Context("when the service instance doesn't exist", () -> {
+                    BeforeEach(() ->
+                            when(instanceRepo.find(eq(SERVICE_INSTANCE_ID))).thenReturn(null));
+
+                    It("should throw a service-does-not-exist exception on createBindingUser", () -> {
+                        try {
+                            workflow.createBindingUser();
+                        } catch (ServiceInstanceDoesNotExistException e) {
+                            assert e.getClass().equals(ServiceInstanceDoesNotExistException.class);
+                        }
+                    });
+
+                    It("should throw a service-does-not-exist exception on removeBinding", () -> {
+                        try {
+                            workflow.removeBinding(bindingInstanceFixture());
+                        } catch (ServiceInstanceDoesNotExistException e) {
+                            assert e.getClass().equals(ServiceInstanceDoesNotExistException.class);
+                        }
+                    });
+
+                    It("should throw a service-does-not-exist exception on getCredentials", () -> {
+                        try {
+                            workflow.getCredentials(SECRET_KEY, new HashMap<>());
+                        } catch (ServiceInstanceDoesNotExistException e) {
+                            assert e.getClass().equals(ServiceInstanceDoesNotExistException.class);
+                        }
+                    });
+
+                });
+
+
+                Context("when the service instance exists", () -> {
+                    BeforeEach(() -> {
+                        // Mock out all prefix calls to return prefixed argument
+                        when(ecs.prefix(anyString())).thenAnswer((Answer<String>) invocation -> {
+                            Object[] args = invocation.getArguments();
+                            return (String) args[0];
+                        });
+
+                        // Return a default endpoint
+                        when(ecs.getObjectEndpoint()).thenReturn(OBJ_ENDPOINT);
+
+                        // Mock service instance repo lookups
+                        when(instanceRepo.find(eq(SERVICE_INSTANCE_ID))).thenReturn(serviceInstanceFixture());
+
+                        UserSecretKey userSecretKey = new UserSecretKey();
+                        userSecretKey.setSecretKey(SECRET_KEY);
+                        when(ecs.createUser(eq(BINDING_ID))).thenReturn(userSecretKey);
+
+                        // Create credentials fixture
+                        String s3Url = "http://" + BINDING_ID + ":" + SECRET_KEY +
+                                "@127.0.0.1:9020/" + SERVICE_INSTANCE_ID;
+                        credentials.put("accessKey", BINDING_ID);
+                        credentials.put("secretKey", SECRET_KEY);
+                        credentials.put("endpoint", OBJ_ENDPOINT);
+                        credentials.put("bucket", SERVICE_INSTANCE_ID);
+                        credentials.put("s3Url", s3Url);
+                        credentials.put("path-style-access", true);
+                    });
+
+                    Context("basic bucket binding", () -> {
+
+                        BeforeEach(() ->
+                                doNothing().when(ecs).addUserToBucket(eq(SERVICE_INSTANCE_ID),
+                                        eq(BINDING_ID)));
+
+                        It("should create a new user", () -> {
+                            workflow.createBindingUser();
+                            verify(ecs, times(1))
+                                    .createUser(BINDING_ID);
+                        });
+
+                        It("should add the user to a bucket", () -> {
+                            workflow.createBindingUser();
+                            verify(ecs, times(1))
+                                    .addUserToBucket(eq(SERVICE_INSTANCE_ID), eq(BINDING_ID));
+                        });
+
+                        It("should delete the user", () -> {
+                            workflow.removeBinding(bindingInstanceFixture());
+                            verify(ecs, times(1))
+                                    .deleteUser(BINDING_ID);
+                        });
+
+                        It("should remove the user from a bucket", () -> {
+                            workflow.removeBinding(bindingInstanceFixture());
+                            verify(ecs, times(1))
+                                    .removeUserFromBucket(SERVICE_INSTANCE_ID, BINDING_ID);
+                        });
+
+
+                        Context("with a port in the object endpoint", () ->
+                                It("should return credentials", () -> {
+                                    Map<String, Object> actual =
+                                            workflow.getCredentials(SECRET_KEY, parameters);
+                                    assertCredentialsEqual(actual, credentials);
+                                }));
+
+                        Context("with no port in the object endpoint", () -> {
+                            BeforeEach(() -> {
+                                when(ecs.getObjectEndpoint()).thenReturn("http://127.0.0.1");
+                                String s3Url = "http://" + BINDING_ID + ":" + SECRET_KEY + "@127.0.0.1/" +
+                                        SERVICE_INSTANCE_ID;
+                                credentials.put("s3Url", s3Url);
+                                credentials.put("endpoint", "http://127.0.0.1");
+                            });
+
+                            It("should return credentials", () -> {
+                                Map<String, Object> actual =
+                                        workflow.getCredentials(SECRET_KEY, parameters);
+                                assertCredentialsEqual(actual, credentials);
+                            });
+
+                        });
+
+                        It("should return a binding", () -> {
+                            ServiceInstanceBinding binding = workflow.getBinding(credentials);
+                            assertEquals(binding.getBindingId(), BINDING_ID);
+                            assertCredentialsEqual(binding.getCredentials(), credentials);
+                            assertEquals(binding.getServiceDefinitionId(), BUCKET_SERVICE_ID);
+                            assertEquals(binding.getPlanId(), BUCKET_PLAN_ID1);
+                        });
+
+                        It("should return a response", () -> {
+                            CreateServiceInstanceAppBindingResponse resp =
+                                    workflow.getResponse(credentials);
+                            assertCredentialsEqual(resp.getCredentials(), credentials);
+                        });
+                    });
+
+                    Context("permissions bucket binding", () -> {
+                        BeforeEach(() -> {
+                            // Add params to workflow
+                            List<String> readOnlyPerms =
+                                    Lists.newArrayList("READ", "READ_ACL");
+                            parameters.put("permissions", readOnlyPerms);
+
+                            CreateServiceInstanceBindingRequest req = bucketBindingRequestFixture(parameters);
+                            workflow = workflow.withCreateRequest(req);
+
+                            doNothing().when(ecs).addUserToBucket(eq(SERVICE_INSTANCE_ID),
+                                    eq(BINDING_ID), any(listClass));
+                        });
+
+                        It("should add the user to the bucket with ACL", () -> {
+                            workflow.createBindingUser();
+                            verify(ecs, times(1))
+                                    .addUserToBucket(eq(SERVICE_INSTANCE_ID), eq(BINDING_ID),
+                                            permsCaptor.capture());
+                            List perms = permsCaptor.getValue();
+                            assertEquals(2, perms.size());
+                            assertEquals("READ", perms.get(0));
+                            assertEquals("READ_ACL", perms.get(1));
+                        });
+                    });
+
+                    Context("without path style access in binding", () -> {
+                        BeforeEach(() -> {
+                            parameters.put("path-style-access", false);
+
+                            CreateServiceInstanceBindingRequest req = bucketBindingRequestFixture(parameters);
+                            workflow = workflow.withCreateRequest(req);
+
+                            String s3Url = "http://" + BINDING_ID + ":" + SECRET_KEY + "@" +
+                                    SERVICE_INSTANCE_ID + ".127.0.0.1:9020";
+                            credentials.put("s3Url", s3Url);
+                            credentials.put("path-style-access", false);
+                        });
+
+                        It("should return credentials with host-style access", () -> {
+                            Map<String, Object> actual = workflow.getCredentials(SECRET_KEY, parameters);
+                            assertCredentialsEqual(actual, credentials);
+                        });
+                    });
+
+                    Context("with volume mount", () -> {
+                        BeforeEach(() ->
+                                when(ecs.getBucketFileEnabled(eq(SERVICE_INSTANCE_ID)))
+                                        .thenReturn(true));
+
+                        Context("at bucket root", () -> {
+                            BeforeEach(() -> {
+                                String path = "/ns1/" + SERVICE_INSTANCE_ID + "/";
+                                when(ecs.addExportToBucket(eq(SERVICE_INSTANCE_ID), any(String.class)))
+                                        .thenReturn(path);
+                                doNothing().when(ecs).deleteUserMap(eq(BINDING_ID), any(String.class));
+                            });
+
+                            It("should create an NFS export", () -> {
+                                workflow.createBindingUser();
+
+                                verify(ecs, times(1))
+                                        .getBucketFileEnabled(eq(SERVICE_INSTANCE_ID));
+                                verify(ecs, times(1))
+                                        .createUser(eq(BINDING_ID));
+                                verify(ecs, times(1))
+                                        .addExportToBucket(eq(SERVICE_INSTANCE_ID), pathCaptor.capture());
+                                assertEquals(pathCaptor.getValue(), "");
+                            });
+
+                            It("should delete the NFS export", () -> {
+                                workflow.removeBinding(bindingInstanceVolumeMountFixture());
+                                verify(ecs, times(1))
+                                        .deleteUser(BINDING_ID);
+                                verify(ecs, times(1))
+                                        .deleteUserMap(eq(BINDING_ID), eq("456"));
+                            });
+
+                            It("should return a binding mount", () -> {
+                                workflow.createBindingUser();
+                                ServiceInstanceBinding binding = workflow.getBinding(credentials);
+
+                                assertEquals(binding.getBindingId(), BINDING_ID);
+
+                                List<VolumeMount> mounts = binding.getVolumeMounts();
+                                assertEquals(1, mounts.size());
+
+                                String containerDir = "/var/vcap/data/" + BINDING_ID;
+                                assertEquals(containerDir, mounts.get(0).getContainerDir());
+                            });
+
+                            It("should return a response with mount", () -> {
+                                workflow.createBindingUser();
+                                CreateServiceInstanceAppBindingResponse resp =
+                                        workflow.getResponse(credentials);
+
+                                List<VolumeMount> mounts = resp.getVolumeMounts();
+                                assertEquals(1, mounts.size());
+
+                                String containerDir = "/var/vcap/data/" + BINDING_ID;
+                                assertEquals(containerDir, mounts.get(0).getContainerDir());
+                            });
+                        });
+
+                        Context("at nested path", () -> {
+                            BeforeEach(() -> {
+                                parameters.put("export", "some-path");
+                                workflow = workflow.withCreateRequest(bucketBindingRequestFixture(parameters));
+                                String path = "/ns1/" + SERVICE_INSTANCE_ID + "/some-path";
+                                when(ecs.addExportToBucket(eq(SERVICE_INSTANCE_ID), any(String.class)))
+                                        .thenReturn(path);
+                            });
+
+                            It("should create an NFS export", () -> {
+                                workflow.createBindingUser();
+
+                                verify(ecs, times(1))
+                                        .createUser(eq(BINDING_ID));
+                                verify(ecs, times(1))
+                                        .addExportToBucket(eq(SERVICE_INSTANCE_ID), pathCaptor.capture());
+                                assertEquals(pathCaptor.getValue(), "some-path");
+                            });
+                        });
+
+                    });
+                });
+            });
+        });
+    }
+
+    private static void assertCredentialsEqual(Map<String, Object> actual, Map<String, Object> credentials) {
+        assertEquals(credentials.get("accessKey"), actual.get("accessKey"));
+        assertEquals(credentials.get("secretKey"), actual.get("secretKey"));
+        assertEquals(credentials.get("endpoint"), actual.get("endpoint"));
+        assertEquals(credentials.get("bucket"), actual.get("bucket"));
+        assertEquals(credentials.get("s3Url"), actual.get("s3Url"));
+        assertEquals(credentials.get("path-style-access"), actual.get("path-style-access"));
+    }
+}

--- a/src/test/java/com/emc/ecs/cloudfoundry/broker/service/EcsServiceInstanceBindingServiceTest.java
+++ b/src/test/java/com/emc/ecs/cloudfoundry/broker/service/EcsServiceInstanceBindingServiceTest.java
@@ -22,7 +22,6 @@ import org.springframework.cloud.servicebroker.model.SharedVolumeDevice;
 import org.springframework.cloud.servicebroker.model.VolumeMount;
 
 import javax.xml.bind.JAXBException;
-import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -343,7 +342,7 @@ public class EcsServiceInstanceBindingServiceTest {
         ArgumentCaptor<ServiceInstanceBinding> bindingCaptor =
                 ArgumentCaptor.forClass(ServiceInstanceBinding.class);
         ArgumentCaptor<ServiceInstance> instanceCaptor =
-                ArgumentCaptor .forClass(ServiceInstance.class);
+                ArgumentCaptor.forClass(ServiceInstance.class);
         when(instanceRepository.find(SERVICE_INSTANCE_ID)).thenReturn(serviceInstanceFixture());
         doNothing().when(instanceRepository).save(instanceCaptor.capture());
         doNothing().when(repository).save(bindingCaptor.capture());

--- a/src/test/java/com/emc/ecs/common/Fixtures.java
+++ b/src/test/java/com/emc/ecs/common/Fixtures.java
@@ -10,10 +10,7 @@ import org.springframework.cloud.servicebroker.model.*;
 import org.springframework.cloud.servicebroker.model.fixture.ServiceInstanceBindingFixture;
 import org.springframework.cloud.servicebroker.model.fixture.ServiceInstanceFixture;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class Fixtures {
     private static final String QUOTA = "quota";
@@ -72,6 +69,7 @@ public class Fixtures {
     public static final String REMOTE_CONNECT_KEY = "95cb87f5-80d3-48b7-b860-072aeae4a918";
     public static final String EXPORT_NAME = "/export/dir";
     public static final String VOLUME_MOUNT = "/mount/dir";
+    public static final String SECRET_KEY = "6b056992-a14a-4fd1-a642-f44a821a7755";
 
     public static ServiceDefinitionProxy bucketServiceFixture() {
     /*
@@ -260,6 +258,15 @@ public class Fixtures {
                 .withServiceInstanceId(SERVICE_INSTANCE_ID);
     }
 
+    public static CreateServiceInstanceBindingRequest bucketBindingRequestFixture(Map<String, Object> parameters) {
+        Map<String, Object> bindResource = new HashMap<>();
+        bindResource.put("app_guid", APP_GUID);
+        return new CreateServiceInstanceBindingRequest(BUCKET_SERVICE_ID,
+                BUCKET_PLAN_ID1, APP_GUID, bindResource, parameters)
+                .withBindingId(BINDING_ID)
+                .withServiceInstanceId(SERVICE_INSTANCE_ID);
+    }
+
     public static CreateServiceInstanceBindingRequest bucketBindingExportRequestFixture() {
         Map<String, Object> bindResource = new HashMap<>();
         bindResource.put("app_guid", APP_GUID);
@@ -298,6 +305,30 @@ public class Fixtures {
                 ServiceInstanceBindingFixture.buildCreateAppBindingRequest());
         binding.setBindingId("service-inst-bind-one-id");
         binding.setCredentials(creds);
+        return binding;
+    }
+
+    public static ServiceInstanceBinding bindingInstanceVolumeMountFixture()
+            throws EcsManagementClientException,
+            EcsManagementResourceNotFoundException {
+        Map<String, Object> creds = new HashMap<>();
+        creds.put("accessKey", "user");
+        creds.put("bucket", "bucket");
+        creds.put("secretKey", "password");
+        creds.put("endpoint", OBJ_ENDPOINT);
+        ServiceInstanceBinding binding = new ServiceInstanceBinding(
+                ServiceInstanceBindingFixture.buildCreateAppBindingRequest());
+        binding.setBindingId("service-inst-bind-one-id");
+        binding.setCredentials(creds);
+        Map<String, Object> opts = new HashMap<>();
+        opts.put("source", "nfs://127.0.0.1/ns1/service-inst-id/");
+        opts.put("uid", "456");
+        List<VolumeMount> mounts = Arrays.asList(
+            new VolumeMount("nfsv3driver", "/var/vcap/data/" + BINDING_ID,
+                    VolumeMount.Mode.READ_WRITE, VolumeMount.DeviceType.SHARED,
+                    new SharedVolumeDevice("123", opts))
+        );
+        binding.setVolumeMounts(mounts);
         return binding;
     }
 

--- a/src/test/resources/wiremockMgmt/mappings/bucket-acl-info-testbucket4.json
+++ b/src/test/resources/wiremockMgmt/mappings/bucket-acl-info-testbucket4.json
@@ -18,6 +18,6 @@
         "headers": {
 			"Content-Type": "application/xml"
 		},
-		"body": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><bucket_info><name>testbucket4</name><tags/><api_type>S3</api_type><block_size>-1</block_size><owner>root</owner><created>2015-12-14T05:13:01.316Z</created><default_retention>-2</default_retention><fs_access_enabled>false</fs_access_enabled><is_stale_allowed>true</is_stale_allowed><locked>false</locked><namespace>ns1</namespace><notification_size>-1</notification_size><vpool>urn:storageos:ReplicationGroupInfo:2ef0a92d-cf88-4933-90ba-90245aa031b1:global</vpool></bucket_info>"
+		"body": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><bucket_acl><bucket>testbucket4</bucket><namespace>ns1</namespace><acl><user_acl><user>root</user><permission>full_control</permission></user_acl></acl></bucket_acl>"
 	}
 }


### PR DESCRIPTION
This PR includes a handful of fixes:

1. It starts the process of refactoring tests for new workflows with Ginkgo4J (starting with BucketBindingWorkflow)
2. It adds support for host style access for buckets in bindings (rather than path-style access) #79 
3. It fixes a bug when an `object-endpoint` is provided without a port #86 
4. It fixes a sneaky wiremock bug for the ACLs -- I have no idea how this snuck through unit testing...
